### PR TITLE
feat: adding multiplicative integration and independent recurrence

### DIFF
--- a/src/RecurrentLayers.jl
+++ b/src/RecurrentLayers.jl
@@ -2,28 +2,29 @@ module RecurrentLayers
 
 using Compat: @compat
 using Flux: _size_check, _match_eltype, chunk, create_bias, zeros_like, glorot_uniform,
-            scan, @layer, default_rng, Chain, Dropout, sigmoid_fast, tanh_fast, relu
+    scan, @layer, default_rng, Chain, Dropout, sigmoid_fast, tanh_fast, relu
 import Flux: initialstates
 import Functors: functor
 using LinearAlgebra: I, transpose
 using NNlib: fast_act
 
 export AntisymmetricRNNCell, ATRCell, BRCell, CFNCell, coRNNCell, FastGRNNCell, FastRNNCell,
-       FSRNNCell, GatedAntisymmetricRNNCell, IndRNNCell, JANETCell, LEMCell, LiGRUCell,
-       LightRUCell, MGUCell, MinimalRNNCell, MultiplicativeLSTMCell, MUT1Cell, MUT2Cell,
-       MUT3Cell, NASCell, OriginalLSTMCell, NBRCell,
-       PeepholeLSTMCell, RANCell, RHNCell, SCRNCell, SGRNCell, STARCell,
-       TGRUCell,
-       TLSTMCell, TRNNCell, UGRNNCell, UnICORNNCell, WMCLSTMCell
+    FSRNNCell, GatedAntisymmetricRNNCell, IndRNNCell, JANETCell, LEMCell, LiGRUCell,
+    LightRUCell, MGUCell, MinimalRNNCell, MultiplicativeLSTMCell, MUT1Cell, MUT2Cell,
+    MUT3Cell, NASCell, OriginalLSTMCell, NBRCell,
+    PeepholeLSTMCell, RANCell, RHNCell, SCRNCell, SGRNCell, STARCell,
+    TGRUCell,
+    TLSTMCell, TRNNCell, UGRNNCell, UnICORNNCell, WMCLSTMCell
 export AntisymmetricRNN, ATR, BR, CFN, coRNN, FastGRNN, FastRNN, FSRNN,
-       GatedAntisymmetricRNN,
-       IndRNN, JANET, LEM, LiGRU, LightRU, MGU, MinimalRNN, MultiplicativeLSTM, MUT1, MUT2,
-       MUT3, NAS, OriginalLSTM, NBR,
-       PeepholeLSTM, RAN, RHN, SCRN, SGRN, STAR, TGRU, TLSTM, TRNN, UGRNN, UnICORNN, WMCLSTM
+    GatedAntisymmetricRNN,
+    IndRNN, JANET, LEM, LiGRU, LightRU, MGU, MinimalRNN, MultiplicativeLSTM, MUT1, MUT2,
+    MUT3, NAS, OriginalLSTM, NBR,
+    PeepholeLSTM, RAN, RHN, SCRN, SGRN, STAR, TGRU, TLSTM, TRNN, UGRNN, UnICORNN, WMCLSTM
 export Multiplicative, StackedRNN
 
 @compat(public, (initialstates))
 
+include("base_functions.jl")
 include("generics.jl")
 
 include("cells/antisymmetricrnn_cell.jl")
@@ -76,7 +77,7 @@ rcells = (
 for (rlayer, rcell) in zip(rlayers, rcells)
     @eval begin
         function ($rlayer)(rc::$rcell; return_state::Bool=false)
-            return $rlayer{return_state, typeof(rc)}(rc)
+            return $rlayer{return_state,typeof(rc)}(rc)
         end
 
         # why wont' this work?

--- a/src/base_functions.jl
+++ b/src/base_functions.jl
@@ -1,0 +1,15 @@
+function dense_proj(weight::AbstractMatrix, inp_or_state::AbstractVector, bias::AbstractVector)
+    return weight * inp_or_state .+ bias
+end
+
+function dense_proj(weight::AbstractVector, inp_or_state::AbstractVector, bias::AbstractVector)
+    return @. weight * inp_or_state + bias
+end
+
+function add_projections(weight_b_ih::AbstractVector, weight_b_hh::AbstractVector)
+    return weight_b_ih .+ weight_b_hh
+end
+
+function mul_projections(weight_b_ih::AbstractVector, weight_b_hh::AbstractVector)
+    return weight_b_ih .* weight_b_hh
+end

--- a/src/cells/antisymmetricrnn_cell.jl
+++ b/src/cells/antisymmetricrnn_cell.jl
@@ -3,7 +3,9 @@
     AntisymmetricRNNCell(input_size => hidden_size, [activation];
         init_kernel = glorot_uniform,
         init_recurrent_kernel = glorot_uniform,
-        bias = true, epsilon=1.0)
+        independent_recurrence = false, integration_fn = :addition,
+        bias = true, recurrent_bias = true,
+        epsilon=1.0, gamma = 0.0)
 
 
 Antisymmetric recurrent cell [Chang2019](@cite).
@@ -20,7 +22,12 @@ See [`AntisymmetricRNN`](@ref) for a layer that processes entire sequences.
     Default is `glorot_uniform`.
 - `init_recurrent_kernel`: initializer for the hidden to hidden weights.
     Default is `glorot_uniform`.
-- `bias`: include a bias or not. Default is `true`.
+- `bias`: include input to recurrent bias or not. Default is `true`.
+- `recurrent_bias`: include recurrent to recurrent bias or not. Default is `true`.
+- `independent_recurrence`: flag to toggle independent recurrence. If `true`, the
+  recurrent to recurrent weights are a vector instead of a matrix. Default `false`.
+- `integration_fn`: determines how the input and hidden projections are combined. The
+  options are `:addition` and `:multiplicative_integration`. Defaults to `:addition`.
 - `epsilon`: step size. Default is 1.0.
 - `gamma`: strength of diffusion. Default is 0.0.
 
@@ -49,41 +56,57 @@ See [`AntisymmetricRNN`](@ref) for a layer that processes entire sequences.
 - A tuple `(output, state)`, where both elements are given by the updated state
   `new_state`, a tensor of size `hidden_size` or `hidden_size x batch_size`.
 """
-struct AntisymmetricRNNCell{F, I, H, V, E, G} <: AbstractRecurrentCell
+struct AntisymmetricRNNCell{F,I,H,V,W,E,G,A} <: AbstractRecurrentCell
     activation::F
-    Wi::I
-    Wh::H
-    b::V
+    weight_ih::I
+    weight_hh::H
+    bias_ih::V
+    bias_hh::W
     epsilon::E
     gamma::G
+    integration_fn::A
 end
 
 @layer AntisymmetricRNNCell
 
 function AntisymmetricRNNCell(
-        (input_size, hidden_size)::Pair{<:Int, <:Int}, activation=tanh;
-        init_kernel=glorot_uniform, init_recurrent_kernel=glorot_uniform,
-        bias::Bool=true, epsilon=1.0f0, gamma=0.0f0)
-    Wi = init_kernel(hidden_size, input_size)
-    Wh = init_recurrent_kernel(hidden_size, hidden_size)
-    b = create_bias(Wi, bias, size(Wi, 1))
-    T = eltype(Wi)
-    return AntisymmetricRNNCell(activation, Wi, Wh, b, T(epsilon), T(gamma))
+    (input_size, hidden_size)::Pair{<:Int,<:Int}, activation=tanh;
+    init_kernel=glorot_uniform, init_recurrent_kernel=glorot_uniform,
+    bias::Bool=true, recurrent_bias::Bool=true,
+    integration_mode::Symbol=:addition, independent_recurrence::Bool=false,
+    epsilon::AbstractFloat=1.0f0, gamma::AbstractFloat=0.0f0)
+    weight_ih = init_kernel(hidden_size, input_size)
+    if independent_recurrence
+        @warn "AntisymmetricRNNCell does not support independent_recurrence"
+    end
+    weight_hh = init_recurrent_kernel(hidden_size, hidden_size)
+    bias_ih = create_bias(weight_ih, bias, size(weight_ih, 1))
+    bias_hh = create_bias(weight_hh, recurrent_bias, size(weight_hh, 1))
+    T = eltype(weight_ih)
+    if integration_mode == :addition
+        integration_fn = add_projections
+    elseif integration_mode == :multiplicative_integration
+        integration_fn = mul_projections
+    else
+        throw(ArgumentError(
+            "integration_mode must be :addition or :multiplicative_integration; got $integration_mode"
+        ))
+    end
+    return AntisymmetricRNNCell(activation, weight_ih, weight_hh, bias_ih, bias_hh, T(epsilon), T(gamma), integration_fn)
 end
 
 function (asymrnn::AntisymmetricRNNCell)(inp::AbstractVecOrMat, state::AbstractVecOrMat)
-    _size_check(asymrnn, inp, 1 => size(asymrnn.Wi, 2))
-    Wi, Wh, b = asymrnn.Wi, asymrnn.Wh, asymrnn.b
-    epsilon, gamma = asymrnn.epsilon, asymrnn.gamma
-    activation = asymrnn.activation
-    recurrent_matrix = compute_asym_recurrent(Wh, gamma)
-    new_state = state + epsilon .*
-                        activation.(Wi * inp .+ recurrent_matrix * state .+ b)
+    _size_check(asymrnn, inp, 1 => size(asymrnn.weight_ih, 2))
+    recurrent_matrix = compute_asym_recurrent(asymrnn.weight_hh, asymrnn.gamma)
+    proj_ih = dense_proj(asymrnn.weight_ih, inp, asymrnn.bias_ih)
+    proj_hh = dense_proj(recurrent_matrix, state, asymrnn.bias_hh)
+    proj_combined = asymrnn.integration_fn(proj_ih, proj_hh)
+    new_state = state + asymrnn.epsilon .* asymrnn.activation.(proj_combined)
     return new_state, new_state
 end
 
 function Base.show(io::IO, asymrnn::AntisymmetricRNNCell)
-    print(io, "AntisymmetricRNNCell(", size(asymrnn.Wi, 2), " => ", size(asymrnn.Wi, 1))
+    print(io, "AntisymmetricRNNCell(", size(asymrnn.weight_ih, 2), " => ", size(asymrnn.weight_ih, 1))
     print(io, ", ", asymrnn.activation)
     print(io, ")")
 end
@@ -107,6 +130,11 @@ See [`AntisymmetricRNNCell`](@ref) for a layer that processes a single sequence.
 - `init_recurrent_kernel`: initializer for the hidden to hidden weights.
     Default is `glorot_uniform`.
 - `bias`: include a bias or not. Default is `true`
+- `recurrent_bias`: include recurrent to recurrent bias or not. Default is `true`.
+- `independent_recurrence`: flag to toggle independent recurrence. If `true`, the
+  recurrent to recurrent weights are a vector instead of a matrix. Default `false`.
+- `integration_fn`: determines how the input and hidden projections are combined. The
+  options are `:addition` and `:multiplicative_integration`. Defaults to `:addition`.
 - `epsilon`: step size. Default is 1.0.
 - `gamma`: strength of diffusion. Default is 0.0.
 
@@ -136,27 +164,27 @@ See [`AntisymmetricRNNCell`](@ref) for a layer that processes a single sequence.
   When `return_state = true` it returns a tuple of the hidden stats `new_states` and
   the last state of the iteration.
 """
-struct AntisymmetricRNN{S, M} <: AbstractRecurrentLayer{S}
+struct AntisymmetricRNN{S,M} <: AbstractRecurrentLayer{S}
     cell::M
 end
 
 @layer :noexpand AntisymmetricRNN
 
-function AntisymmetricRNN((input_size, hidden_size)::Pair{<:Int, <:Int}, activation=tanh;
-        return_state::Bool=false, kwargs...)
+function AntisymmetricRNN((input_size, hidden_size)::Pair{<:Int,<:Int}, activation=tanh;
+    return_state::Bool=false, kwargs...)
     cell = AntisymmetricRNNCell(input_size => hidden_size, activation; kwargs...)
-    return AntisymmetricRNN{return_state, typeof(cell)}(cell)
+    return AntisymmetricRNN{return_state,typeof(cell)}(cell)
 end
 
 function functor(asymrnn::AntisymmetricRNN{S}) where {S}
     params = (cell=asymrnn.cell,)
-    reconstruct = p -> AntisymmetricRNN{S, typeof(p.cell)}(p.cell)
+    reconstruct = p -> AntisymmetricRNN{S,typeof(p.cell)}(p.cell)
     return params, reconstruct
 end
 
 function Base.show(io::IO, asymrnn::AntisymmetricRNN)
     print(
-        io, "AntisymmetricRNN(", size(asymrnn.cell.Wi, 2), " => ", size(asymrnn.cell.Wi, 1))
+        io, "AntisymmetricRNN(", size(asymrnn.cell.weight_ih, 2), " => ", size(asymrnn.cell.weight_ih, 1))
     print(io, ", ", asymrnn.cell.activation)
     print(io, ")")
 end
@@ -165,7 +193,9 @@ end
     GatedAntisymmetricRNNCell(input_size => hidden_size, [activation];
         init_kernel = glorot_uniform,
         init_recurrent_kernel = glorot_uniform,
-        bias = true, epsilon=1.0)
+        independent_recurrence = false, integration_fn = :addition,
+        bias = true, recurrent_bias = true,
+        epsilon=1.0, gamma = 0.0)
 
 
 Antisymmetric recurrent cell with gating [Chang2019](@cite).
@@ -182,6 +212,10 @@ See [`GatedAntisymmetricRNN`](@ref) for a layer that processes entire sequences.
 - `init_recurrent_kernel`: initializer for the hidden to hidden weights.
     Default is `glorot_uniform`.
 - `bias`: include a bias or not. Default is `true`.
+- `independent_recurrence`: flag to toggle independent recurrence. If `true`, the
+  recurrent to recurrent weights are a vector instead of a matrix. Default `false`.
+- `integration_fn`: determines how the input and hidden projections are combined. The
+  options are `:addition` and `:multiplicative_integration`. Defaults to `:addition`.
 - `epsilon`: step size. Default is 1.0.
 - `gamma`: strength of diffusion. Default is 0.0.
 
@@ -216,44 +250,61 @@ See [`GatedAntisymmetricRNN`](@ref) for a layer that processes entire sequences.
 - A tuple `(output, state)`, where both elements are given by the updated state
   `new_state`, a tensor of size `hidden_size` or `hidden_size x batch_size`.
 """
-struct GatedAntisymmetricRNNCell{I, H, V, E, G} <: AbstractRecurrentCell
-    Wi::I
-    Wh::H
-    b::V
+struct GatedAntisymmetricRNNCell{I,H,V,W,E,G,A} <: AbstractRecurrentCell
+    weight_ih::I
+    weight_hh::H
+    bias_ih::V
+    bias_hh::W
     epsilon::E
     gamma::G
+    integration_fn::A
 end
 
 @layer GatedAntisymmetricRNNCell
 
 function GatedAntisymmetricRNNCell(
-        (input_size, hidden_size)::Pair{<:Int, <:Int};
-        init_kernel=glorot_uniform, init_recurrent_kernel=glorot_uniform,
-        bias::Bool=true, epsilon=1.0f0, gamma=0.0f0)
-    Wi = init_kernel(hidden_size * 2, input_size)
-    Wh = init_recurrent_kernel(hidden_size, hidden_size)
-    b = create_bias(Wi, bias, size(Wi, 1))
-    T = eltype(Wi)
-    return GatedAntisymmetricRNNCell(Wi, Wh, b, T(epsilon), T(gamma))
+    (input_size, hidden_size)::Pair{<:Int,<:Int};
+    init_kernel=glorot_uniform, init_recurrent_kernel=glorot_uniform,
+    bias::Bool=true, recurrent_bias::Bool=true,
+    integration_mode::Symbol=:addition, independent_recurrence::Bool=false,
+    epsilon=1.0f0, gamma=0.0f0)
+    weight_ih = init_kernel(hidden_size * 2, input_size)
+    if independent_recurrence
+        @warn "GatedAntisymmetricRNNCell does not support independent_recurrence"
+    end
+    weight_hh = init_recurrent_kernel(hidden_size, hidden_size)
+    bias_ih = create_bias(weight_ih, bias, size(weight_ih, 1))
+    bias_hh = create_bias(weight_hh, recurrent_bias, size(weight_hh, 1))
+    T = eltype(weight_ih)
+    if integration_mode == :addition
+        integration_fn = add_projections
+    elseif integration_mode == :multiplicative_integration
+        integration_fn = mul_projections
+    else
+        throw(ArgumentError(
+            "integration_mode must be :addition or :multiplicative_integration; got $integration_mode"
+        ))
+    end
+    return GatedAntisymmetricRNNCell(weight_ih, weight_hh, bias_ih, bias_hh, T(epsilon), T(gamma), integration_fn)
 end
 
 function (asymrnn::GatedAntisymmetricRNNCell)(
-        inp::AbstractVecOrMat, state::AbstractVecOrMat)
-    _size_check(asymrnn, inp, 1 => size(asymrnn.Wi, 2))
-    Wi, Wh, b = asymrnn.Wi, asymrnn.Wh, asymrnn.b
-    gxs = chunk(Wi * inp .+ b, 2; dims=1)
-    epsilon, gamma = asymrnn.epsilon, asymrnn.gamma
-    recurrent_matrix = compute_asym_recurrent(Wh, gamma)
-    input_gate = sigmoid_fast.(recurrent_matrix * state .+ gxs[1])
-    new_state = state +
-                epsilon .* input_gate .*
-                tanh_fast.(gxs[2] .+ recurrent_matrix * state)
+    inp::AbstractVecOrMat, state::AbstractVecOrMat)
+    _size_check(asymrnn, inp, 1 => size(asymrnn.weight_ih, 2))
+    recurrent_matrix = compute_asym_recurrent(asymrnn.weight_hh, asymrnn.gamma)
+    proj_ih = dense_proj(asymrnn.weight_ih, inp, asymrnn.bias_ih)
+    proj_hh = dense_proj(recurrent_matrix, state, asymrnn.bias_hh)
+    gxs = chunk(proj_ih, 2; dims=1)
+    proj_combined_1 = asymrnn.integration_fn(gxs[1], proj_hh)
+    proj_combined_2 = asymrnn.integration_fn(gxs[2], proj_hh)
+    input_gate = sigmoid_fast.(proj_combined_1)
+    new_state = state + asymrnn.epsilon .* input_gate .* tanh_fast.(proj_combined_2)
     return new_state, new_state
 end
 
 function Base.show(io::IO, asymrnn::GatedAntisymmetricRNNCell)
     print(io, "GatedAntisymmetricRNNCell(",
-        size(asymrnn.Wi, 2), " => ", size(asymrnn.Wi, 1) ÷ 2)
+        size(asymrnn.weight_ih, 2), " => ", size(asymrnn.weight_ih, 1) ÷ 2)
     print(io, ")")
 end
 
@@ -275,6 +326,11 @@ See [`GatedAntisymmetricRNNCell`](@ref) for a layer that processes a single sequ
 - `init_recurrent_kernel`: initializer for the hidden to hidden weights.
     Default is `glorot_uniform`.
 - `bias`: include a bias or not. Default is `true`.
+- `recurrent_bias`: include recurrent to recurrent bias or not. Default is `true`.
+- `independent_recurrence`: flag to toggle independent recurrence. If `true`, the
+  recurrent to recurrent weights are a vector instead of a matrix. Default `false`.
+- `integration_fn`: determines how the input and hidden projections are combined. The
+  options are `:addition` and `:multiplicative_integration`. Defaults to `:addition`.
 - `epsilon`: step size. Default is 1.0.
 - `gamma`: strength of diffusion. Default is 0.0.
 
@@ -310,31 +366,31 @@ See [`GatedAntisymmetricRNNCell`](@ref) for a layer that processes a single sequ
   When `return_state = true` it returns a tuple of the hidden stats `new_states` and
   the last state of the iteration.
 """
-struct GatedAntisymmetricRNN{S, M} <: AbstractRecurrentLayer{S}
+struct GatedAntisymmetricRNN{S,M} <: AbstractRecurrentLayer{S}
     cell::M
 end
 
 @layer :noexpand GatedAntisymmetricRNN
 
-function GatedAntisymmetricRNN((input_size, hidden_size)::Pair{<:Int, <:Int};
-        return_state::Bool=false, kwargs...)
+function GatedAntisymmetricRNN((input_size, hidden_size)::Pair{<:Int,<:Int};
+    return_state::Bool=false, kwargs...)
     cell = GatedAntisymmetricRNNCell(input_size => hidden_size; kwargs...)
-    return GatedAntisymmetricRNN{return_state, typeof(cell)}(cell)
+    return GatedAntisymmetricRNN{return_state,typeof(cell)}(cell)
 end
 
 function functor(asymrnn::GatedAntisymmetricRNN{S}) where {S}
     params = (cell=asymrnn.cell,)
-    reconstruct = p -> GatedAntisymmetricRNN{S, typeof(p.cell)}(p.cell)
+    reconstruct = p -> GatedAntisymmetricRNN{S,typeof(p.cell)}(p.cell)
     return params, reconstruct
 end
 
 function Base.show(io::IO, asymrnn::GatedAntisymmetricRNN)
     print(
-        io, "GatedAntisymmetricRNN(", size(asymrnn.cell.Wi, 2),
-        " => ", size(asymrnn.cell.Wi, 1) ÷ 2)
+        io, "GatedAntisymmetricRNN(", size(asymrnn.cell.weight_ih, 2),
+        " => ", size(asymrnn.cell.weight_ih, 1) ÷ 2)
     print(io, ")")
 end
 
-function compute_asym_recurrent(Wh::AbstractArray, gamma::AbstractFloat)
-    return Wh .- transpose(Wh) .- gamma .* Matrix{eltype(Wh)}(I, size(Wh, 1), size(Wh, 1))
+function compute_asym_recurrent(weight_hh::AbstractArray, gamma::AbstractFloat)
+    return weight_hh .- transpose(weight_hh) .- gamma .* Matrix{eltype(weight_hh)}(I, size(weight_hh, 1), size(weight_hh, 1))
 end

--- a/src/cells/br_cell.jl
+++ b/src/cells/br_cell.jl
@@ -2,7 +2,9 @@
 @doc raw"""
     BRCell(input_size => hidden_size;
         init_kernel = glorot_uniform,
-        init_recurrent_kernel = glorot_uniform)
+        init_recurrent_kernel = glorot_uniform
+        bias = true, recurrent_bias = true,
+        independent_recurrence = false, integration_fn = :addition)
 
 
 Bistable recurrent cell [Vecoven2021](@cite).
@@ -19,6 +21,11 @@ See [`BR`](@ref) for a layer that processes entire sequences.
 - `init_recurrent_kernel`: initializer for the hidden to hidden weights.
     Default is `glorot_uniform`.
 - `bias`: include a bias or not. Default is `true`.
+- `recurrent_bias`: include recurrent to recurrent bias or not. Default is `true`.
+- `independent_recurrence`: hard-coded to `true` in this architecture. For the
+  architecture without independent recurrence plese refer to [`NBRCell`](@ref)
+- `integration_fn`: determines how the input and hidden projections are combined. The
+  options are `:addition` and `:multiplicative_integration`. Defaults to `:addition`.
 
 # Equations
 
@@ -51,31 +58,50 @@ See [`BR`](@ref) for a layer that processes entire sequences.
 - A tuple `(output, state)`, where both elements are given by the updated state
   `new_state`, a tensor of size `hidden_size` or `hidden_size x batch_size`.
 """
-struct BRCell{I, H, V} <: AbstractRecurrentCell
-    Wi::I
-    Wh::H
-    b::V
+struct BRCell{I,H,V,W,A} <: AbstractRecurrentCell
+    weight_ih::I
+    weight_hh::H
+    bias_ih::V
+    bias_hh::W
+    integration_fn::A
 end
 
 @layer BRCell
 
-function BRCell((input_size, hidden_size)::Pair{<:Int, <:Int};
-        init_kernel=glorot_uniform, init_recurrent_kernel=glorot_uniform,
-        bias::Bool=true)
-    Wi = init_kernel(hidden_size * 3, input_size)
-    Wh = init_recurrent_kernel(hidden_size * 2)
-    b = create_bias(Wi, bias, size(Wi, 1))
-    return BRCell(Wi, Wh, b)
+function BRCell((input_size, hidden_size)::Pair{<:Int,<:Int};
+    init_kernel=glorot_uniform, init_recurrent_kernel=glorot_uniform,
+    bias::Bool=true, recurrent_bias::Bool=true,
+    integration_mode::Symbol=:addition, independent_recurrence::Bool=true)
+    weight_ih = init_kernel(hidden_size * 3, input_size)
+    weight_hh = init_recurrent_kernel(hidden_size * 2)
+    bias_ih = create_bias(weight_ih, bias, size(weight_ih, 1))
+    bias_hh = create_bias(weight_hh, recurrent_bias, size(weight_hh, 1))
+    if !independent_recurrence
+        @warn "independent_recurrence defaults to true in BRCell"
+    end
+    if integration_mode == :addition
+        integration_fn = add_projections
+    elseif integration_mode == :multiplicative_integration
+        integration_fn = mul_projections
+    else
+        throw(ArgumentError(
+            "integration_mode must be :addition or :multiplicative_integration; got $integration_mode"
+        ))
+    end
+    return BRCell(weight_ih, weight_hh, bias_ih, bias_hh, integration_fn)
 end
 
 function (br::BRCell)(inp::AbstractVecOrMat, state::AbstractVecOrMat)
-    _size_check(br, inp, 1 => size(br.Wi, 2))
-    Wi, wh, b = br.Wi, vec(br.Wh), br.b
-    gxs = chunk(Wi * inp .+ b, 3; dims=1)
-    ws = chunk(wh, 2; dims=1)
-    t_ones = eltype(Wi)(1.0)
-    h1 = @. gxs[1] + ws[1] * state
-    h2 = @. gxs[2] + ws[2] * state
+    _size_check(br, inp, 1 => size(br.weight_ih, 2))
+    proj_ih = dense_proj(br.weight_ih, inp, br.bias_ih)
+    gxs = chunk(proj_ih, 3; dims=1)
+    whs = chunk(br.weight_hh, 2; dims=1)
+    bhs = chunk(br.bias_hh, 2; dims=1)
+    proj_ih_1 = dense_proj(whs[1], state, bhs[1])
+    proj_ih_2 = dense_proj(whs[2], state, bhs[2])
+    t_ones = eltype(br.weight_ih)(1.0)
+    h1 = br.integration_fn(gxs[1], proj_ih_1)
+    h2 = br.integration_fn(gxs[2], proj_ih_2)
     modulation_gate = @. t_ones + tanh_fast(h1)
     candidate_state = @. sigmoid_fast(h2)
     h3 = @. gxs[3] + modulation_gate * state
@@ -84,11 +110,11 @@ function (br::BRCell)(inp::AbstractVecOrMat, state::AbstractVecOrMat)
 end
 
 function initialstates(br::BRCell)
-    return zeros_like(br.Wh, size(br.Wh, 1) ÷ 2)
+    return zeros_like(br.weight_hh, size(br.weight_hh, 1) ÷ 2)
 end
 
 function Base.show(io::IO, br::BRCell)
-    print(io, "BRCell(", size(br.Wi, 2), " => ", size(br.Wi, 1) ÷ 3)
+    print(io, "BRCell(", size(br.weight_ih, 2), " => ", size(br.weight_ih, 1) ÷ 3)
     print(io, ")")
 end
 
@@ -110,6 +136,11 @@ See [`BRCell`](@ref) for a layer that processes a single sequence.
 - `init_recurrent_kernel`: initializer for the hidden to hidden weights.
     Default is `glorot_uniform`.
 - `bias`: include a bias or not. Default is `true`
+- `recurrent_bias`: include recurrent to recurrent bias or not. Default is `true`.
+- `independent_recurrence`: hard-coded to `true` in this architecture. For the
+  architecture without independent recurrence plese refer to [`NBR`](@ref)
+- `integration_fn`: determines how the input and hidden projections are combined. The
+  options are `:addition` and `:multiplicative_integration`. Defaults to `:addition`.
 
 # Equations
 
@@ -143,34 +174,36 @@ See [`BRCell`](@ref) for a layer that processes a single sequence.
   When `return_state = true` it returns a tuple of the hidden stats `new_states` and
   the last state of the iteration.
 """
-struct BR{S, M} <: AbstractRecurrentLayer{S}
+struct BR{S,M} <: AbstractRecurrentLayer{S}
     cell::M
 end
 
 @layer :noexpand BR
 
-function BR((input_size, hidden_size)::Pair{<:Int, <:Int};
-        return_state::Bool=false, kwargs...)
+function BR((input_size, hidden_size)::Pair{<:Int,<:Int};
+    return_state::Bool=false, kwargs...)
     cell = BRCell(input_size => hidden_size; kwargs...)
-    return BR{return_state, typeof(cell)}(cell)
+    return BR{return_state,typeof(cell)}(cell)
 end
 
 function functor(br::BR{S}) where {S}
     params = (cell=br.cell,)
-    reconstruct = p -> BR{S, typeof(p.cell)}(p.cell)
+    reconstruct = p -> BR{S,typeof(p.cell)}(p.cell)
     return params, reconstruct
 end
 
 function Base.show(io::IO, br::BR)
     print(
-        io, "BR(", size(br.cell.Wi, 2), " => ", size(br.cell.Wi, 1) ÷ 3)
+        io, "BR(", size(br.cell.weight_ih, 2), " => ", size(br.cell.weight_ih, 1) ÷ 3)
     print(io, ")")
 end
 
 @doc raw"""
     NBRCell(input_size => hidden_size;
         init_kernel = glorot_uniform,
-        init_recurrent_kernel = glorot_uniform)
+        init_recurrent_kernel = glorot_uniform,
+        bias = true, recurrent_bias = true,
+        independent_recurrence = false, integration_fn = :addition)
 
 
 Recurrently neuromodulated bistable recurrent cell [Vecoven2021](@cite).
@@ -187,6 +220,11 @@ See [`NBR`](@ref) for a layer that processes entire sequences.
 - `init_recurrent_kernel`: initializer for the hidden to hidden weights.
     Default is `glorot_uniform`.
 - `bias`: include a bias or not. Default is `true`.
+- `recurrent_bias`: include recurrent to recurrent bias or not. Default is `true`.
+- `independent_recurrence`: hard-coded to `false` in this architecture. For the
+  architecture with independent recurrence plese refer to [`BRCell`](@ref)
+- `integration_fn`: determines how the input and hidden projections are combined. The
+  options are `:addition` and `:multiplicative_integration`. Defaults to `:addition`.
 
 # Equations
 
@@ -219,31 +257,48 @@ See [`NBR`](@ref) for a layer that processes entire sequences.
 - A tuple `(output, state)`, where both elements are given by the updated state
   `new_state`, a tensor of size `hidden_size` or `hidden_size x batch_size`.
 """
-struct NBRCell{I, H, V} <: AbstractRecurrentCell
-    Wi::I
-    Wh::H
-    b::V
+struct NBRCell{I,H,V,W,A} <: AbstractRecurrentCell
+    weight_ih::I
+    weight_hh::H
+    bias_ih::V
+    bias_hh::W
+    integration_fn::A
 end
 
 @layer NBRCell
 
-function NBRCell((input_size, hidden_size)::Pair{<:Int, <:Int};
-        init_kernel=glorot_uniform, init_recurrent_kernel=glorot_uniform,
-        bias::Bool=true)
-    Wi = init_kernel(hidden_size * 3, input_size)
-    Wh = init_recurrent_kernel(hidden_size * 2, hidden_size)
-    b = create_bias(Wi, bias, size(Wi, 1))
-    return NBRCell(Wi, Wh, b)
+function NBRCell((input_size, hidden_size)::Pair{<:Int,<:Int};
+    init_kernel=glorot_uniform, init_recurrent_kernel=glorot_uniform,
+    bias::Bool=true, recurrent_bias::Bool=true,
+    integration_mode::Symbol=:addition, independent_recurrence::Bool=false)
+    weight_ih = init_kernel(hidden_size * 3, input_size)
+    weight_hh = init_recurrent_kernel(hidden_size * 2, hidden_size)
+    bias_ih = create_bias(weight_ih, bias, size(weight_ih, 1))
+    bias_hh = create_bias(weight_hh, recurrent_bias, size(weight_hh, 1))
+    if independent_recurrence
+        @warn "independent_recurrence defaults to false in NBRCell"
+    end
+    if integration_mode == :addition
+        integration_fn = add_projections
+    elseif integration_mode == :multiplicative_integration
+        integration_fn = mul_projections
+    else
+        throw(ArgumentError(
+            "integration_mode must be :addition or :multiplicative_integration; got $integration_mode"
+        ))
+    end
+    return NBRCell(weight_ih, weight_hh, bias_ih, bias_hh, integration_fn)
 end
 
 function (nbr::NBRCell)(inp::AbstractVecOrMat, state::AbstractVecOrMat)
-    _size_check(nbr, inp, 1 => size(nbr.Wi, 2))
-    Wi, Wh, b = nbr.Wi, nbr.Wh, nbr.b
-    gxs = chunk(Wi * inp .+ b, 3; dims=1)
-    ghs = chunk(Wh * state, 2; dims=1)
-    t_ones = eltype(Wi)(1.0)
-    h1 = @. gxs[1] + gxs[1]
-    h2 = @. gxs[2] + gxs[2]
+    _size_check(nbr, inp, 1 => size(nbr.weight_ih, 2))
+    proj_ih = dense_proj(nbr.weight_ih, inp, nbr.bias_ih)
+    proj_hh = dense_proj(nbr.weight_hh, state, nbr.bias_hh)
+    gxs = chunk(proj_ih, 3; dims=1)
+    ghs = chunk(proj_hh, 2; dims=1)
+    t_ones = eltype(nbr.weight_ih)(1.0)
+    h1 = nbr.integration_fn(gxs[1], gxs[1])
+    h2 = nbr.integration_fn(gxs[2], gxs[2])
     modulation_gate = @. t_ones + tanh_fast(h1)
     candidate_state = @. sigmoid_fast(h2)
     h3 = @. gxs[3] + modulation_gate * state
@@ -252,7 +307,7 @@ function (nbr::NBRCell)(inp::AbstractVecOrMat, state::AbstractVecOrMat)
 end
 
 function Base.show(io::IO, nbr::NBRCell)
-    print(io, "NBRCell(", size(nbr.Wi, 2), " => ", size(nbr.Wi, 1) ÷ 3)
+    print(io, "NBRCell(", size(nbr.weight_ih, 2), " => ", size(nbr.weight_ih, 1) ÷ 3)
     print(io, ")")
 end
 
@@ -307,26 +362,26 @@ See [`NBRCell`](@ref) for a layer that processes a single sequence.
   When `return_state = true` it returns a tuple of the hidden stats `new_states` and
   the last state of the iteration.
 """
-struct NBR{S, M} <: AbstractRecurrentLayer{S}
+struct NBR{S,M} <: AbstractRecurrentLayer{S}
     cell::M
 end
 
 @layer :noexpand NBR
 
-function NBR((input_size, hidden_size)::Pair{<:Int, <:Int};
-        return_state::Bool=false, kwargs...)
+function NBR((input_size, hidden_size)::Pair{<:Int,<:Int};
+    return_state::Bool=false, kwargs...)
     cell = NBRCell(input_size => hidden_size; kwargs...)
-    return NBR{return_state, typeof(cell)}(cell)
+    return NBR{return_state,typeof(cell)}(cell)
 end
 
 function functor(nbr::NBR{S}) where {S}
     params = (cell=nbr.cell,)
-    reconstruct = p -> NBR{S, typeof(p.cell)}(p.cell)
+    reconstruct = p -> NBR{S,typeof(p.cell)}(p.cell)
     return params, reconstruct
 end
 
 function Base.show(io::IO, nbr::NBR)
     print(
-        io, "NBR(", size(nbr.cell.Wi, 2), " => ", size(nbr.cell.Wi, 1) ÷ 3)
+        io, "NBR(", size(nbr.cell.weight_ih, 2), " => ", size(nbr.cell.weight_ih, 1) ÷ 3)
     print(io, ")")
 end

--- a/src/generics.jl
+++ b/src/generics.jl
@@ -2,12 +2,12 @@ abstract type AbstractRecurrentCell end
 abstract type AbstractDoubleRecurrentCell <: AbstractRecurrentCell end
 
 function initialstates(rcell::AbstractRecurrentCell)
-    return zeros_like(rcell.Wh, size(rcell.Wh, 2))
+    return zeros_like(rcell.weight_hh, size(rcell.weight_hh, 2))
 end
 
 function initialstates(rcell::AbstractDoubleRecurrentCell)
-    state = zeros_like(rcell.Wh, size(rcell.Wh, 2))
-    second_state = zeros_like(rcell.Wh, size(rcell.Wh, 2))
+    state = zeros_like(rcell.weight_hh, size(rcell.weight_hh, 2))
+    second_state = zeros_like(rcell.weight_hh, size(rcell.weight_hh, 2))
     return state, second_state
 end
 
@@ -28,25 +28,25 @@ function (rlayer::AbstractRecurrentLayer)(inp::AbstractArray)
 end
 
 function (rlayer::AbstractRecurrentLayer{false})(inp::AbstractArray,
-        state::Union{AbstractVecOrMat, Tuple{AbstractVecOrMat, AbstractVecOrMat},
-            Tuple{AbstractVecOrMat, AbstractVecOrMat, AbstractVecOrMat}})
+    state::Union{AbstractVecOrMat,Tuple{AbstractVecOrMat,AbstractVecOrMat},
+        Tuple{AbstractVecOrMat,AbstractVecOrMat,AbstractVecOrMat}})
     @assert ndims(inp) == 2 || ndims(inp) == 3
-    @assert typeof(state)==typeof(initialstates(rlayer)) """\n
-       The layer $rlayer is calling states not supported by its
-       forward method. Check if this is a single or double return
-       recurrent layer, and adjust your inputs accordingly.
-    """
+    @assert typeof(state) == typeof(initialstates(rlayer)) """\n
+         The layer $rlayer is calling states not supported by its
+         forward method. Check if this is a single or double return
+         recurrent layer, and adjust your inputs accordingly.
+      """
     return first(scan(rlayer.cell, inp, state))
 end
 
 function (rlayer::AbstractRecurrentLayer{true})(inp::AbstractArray,
-        state::Union{AbstractVecOrMat, Tuple{AbstractVecOrMat, AbstractVecOrMat},
-            Tuple{AbstractVecOrMat, AbstractVecOrMat, AbstractVecOrMat}})
+    state::Union{AbstractVecOrMat,Tuple{AbstractVecOrMat,AbstractVecOrMat},
+        Tuple{AbstractVecOrMat,AbstractVecOrMat,AbstractVecOrMat}})
     @assert ndims(inp) == 2 || ndims(inp) == 3
-    @assert typeof(state)==typeof(initialstates(rlayer)) """\n
-       The layer $rlayer is calling states not supported by its
-       forward method. Check if this is a single or double return
-       recurrent layer, and adjust your inputs accordingly.
-    """
+    @assert typeof(state) == typeof(initialstates(rlayer)) """\n
+         The layer $rlayer is calling states not supported by its
+         forward method. Check if this is a single or double return
+         recurrent layer, and adjust your inputs accordingly.
+      """
     return scan(rlayer.cell, inp, state)
 end


### PR DESCRIPTION
There's a lot of stuff going on with this PR sadly, but I didn't feel like passing through the cells multiple times.

- [ ] Change weight names from `Wi`, `Wh` to `weight_ih`, `weight_hh`. Closes #126 
- [ ] Add `bias_hh`
- [ ] Add `recurrent_bias` option to toggle `bias_hh`
- [ ] Add `independent_recurrence` toggle to have independent recurrence. Closes #99
- [ ] Add `:multiplicative_integration` option for the integration in the cells. Closes #5

Since the first change is breaking this is the first (and hopefully largest) PR towards v0.3